### PR TITLE
Update main.js

### DIFF
--- a/main.js
+++ b/main.js
@@ -343,6 +343,8 @@ class Shelly extends utils.Adapter {
             }
 
             const typesList = {
+                moisture: { type: 'number', unit: '%' },
+                soil: { type: 'number', unit: 'µS/cm' },
                 battery: { type: 'number', unit: '%' },
                 temperature: { type: 'number', unit: '°C' },
                 humidity: { type: 'number', unit: '%' },


### PR DESCRIPTION
Closes #123
 [Hardware Request]: BLE gateway 3rd party sensor support
added to types to typesList for Ble messages
moisture: { type: 'number', unit: '%' },
soil: { type: 'number', unit: 'µS/cm' },